### PR TITLE
Add gws to distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Currently supported distributions are:
 - [gitjacker](https://github.com/liamg/gitjacker)
 - [goreleaser](https://github.com/goreleaser/goreleaser)
 - [grizzly](https://github.com/grafana/grizzly)
+- [gws](https://github.com/StreakyCobra/gws)
 - [hadolint](https://github.com/hadolint/hadolint)
 - [helm](https://helm.sh/)
 - [helmfile](https://github.com/roboll/helmfile)

--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -162,6 +162,15 @@ sources:
     install:
       type: direct
 
+  gws:
+    list:
+      type: github-releases
+      url: https://api.github.com/repos/StreakyCobra/gws/releases
+    fetch:
+      url: https://github.com/StreakyCobra/gws/releases/download/{{ .Version }}/gws-{{ .Version }}
+    install:
+      type: direct
+
   hey:
     list:
       type: github-releases


### PR DESCRIPTION
gws can be considered as a "feature complete" tool, so there's no more activity on its repository. I don't know if it's legit to add it to binenv, so do you you want with this PR ;)