### PR TITLE
Ignore invalid versions instead of panic

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -533,7 +533,12 @@ func (a *App) updateLocally(which ...string) error {
 
 		// Convert versions to canonical form
 		for _, v := range versions {
-			a.cache[d] = append(a.cache[d], gov.Must(gov.NewVersion(v)).String())
+			version, err := gov.NewVersion(v)
+			if err != nil {
+				a.logger.Warn().Err(err).Msgf("ignoring invalid version for %q", d)
+				continue
+			}
+			a.cache[d] = append(a.cache[d], version.String())
 		}
 	}
 	return nil


### PR DESCRIPTION
TL;DR: This change make `binenv update` ignoring invalid version names instead of failing with a panic.

I tried to add [Hashicorp Packer](https://github.com/hashicorp/packer/releases) tool in distributions and I found that it is not possible because of one of their releases (the nightly one).
As you can see,  this tool have a `nightly` version that can't be parsed correctly by the [`go-version` library](https://godoc.org/github.com/hashicorp/go-version) (a library from .... Hashicorp :upside_down_face: ).

Here is the result when you add those lines to `distributions.yaml`.
```yaml
  packer:
    list:
      type: github-releases
      url: https://api.github.com/repos/hashicorp/packer/releases
    fetch:
      url: https://releases.hashicorp.com/packer/{{ .Version }}/packer_{{ .Version }}_{{ .OS }}_{{ .Arch }}.zip
    install:
      type: zip
      binaries:
        - packer
```

```bash
$ binenv update packer
updating distributions 100% || (1/1, 23640 it/s) [0s:0s]
panic: Malformed version: nightly

goroutine 1 [running]:
github.com/hashicorp/go-version.Must(...)
	/home/runner/go/pkg/mod/github.com/hashicorp/go-version@v1.2.1/version.go:104
github.com/devops-works/binenv/internal/app.(*App).updateLocally(0xc00010f7c0, 0xc0001cf060, 0x1, 0x1, 0x0, 0x0)
	/home/runner/work/binenv/binenv/internal/app/app.go:536 +0x9b5
github.com/devops-works/binenv/internal/app.(*App).Update(0xc00010f7c0, 0x0, 0xc0001cf060, 0x1, 0x1, 0x0, 0x0)
	/home/runner/work/binenv/binenv/internal/app/app.go:472 +0x359
github.com/devops-works/binenv/cmd.updateCmd.func1(0xc0001f22c0, 0xc0001cf060, 0x1, 0x1)
	/home/runner/work/binenv/binenv/cmd/update.go:22 +0x1d3
github.com/spf13/cobra.(*Command).execute(0xc0001f22c0, 0xc0001cf030, 0x1, 0x1, 0xc0001f22c0, 0xc0001cf030)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0xc0001e9340, 0x0, 0x81d4a0, 0xc00006a058)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
main.main()
	/home/runner/work/binenv/binenv/main.go:15 +0x2a
```

I suggest this little change in order to only ignore the malformed version instead of just "panics".  Then the command will only print a message.

```bash
$ ./bin/binenv update packer
updating distributions 100% || (1/1, 29560 it/s) [0s:0s]
2020-10-05T18:08:32+02:00 WRN ignoring invalid version for "packer" error="Malformed version: nightly"
```