### PR TITLE
bugfix: glab uses x86_64 for amd64

### DIFF
--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -348,6 +348,7 @@ sources:
   glab:
     description: An open-source GitLab command line tool
     map:
+      amd64: x86_64
       darwin: macOS
       linux: Linux
     list:


### PR DESCRIPTION
Bugfix: glab releases use x86_64 for amd64 architecture.