### PR TITLE
feature: added tfsec for terrform template security analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Currently supported distributions are:
 - [terraform-inventory](https://github.com/adammck/terraform-inventory)
 - [terragrunt](https://terragrunt.gruntwork.io/)
 - [tflint](https://github.com/terraform-linters/tflint/)
+- [tfsec](https://github.com/tfsec/tfsec)
 - [toji](https://github.com/leucos/toji/)
 - [traefik](https://doc.traefik.io/traefik/)
 - [trivy](https://github.com/aquasecurity/trivy)

--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -1355,6 +1355,16 @@ sources:
       binaries:
         - tflint
 
+  tfsec:
+    description: TFsec uses static analysis of your terraform templates to spot potential security issues.
+    list:
+      type: github-releases
+      url: https://api.github.com/repos/tfsec/tfsec/releases
+    fetch:
+      url: https://github.com/tfsec/tfsec/releases/download/v{{ .Version }}/tfsec-{{ .OS }}-{{ .Arch }}
+    install:
+      type: direct
+
   toji:
     description: "Toji is a Toggle ➡ Jira bridge: sync your Toggl entries directly into Jira issues worklog"
     list:


### PR DESCRIPTION
As security engineer I want to have tfsec in the binenv distribution to provide static security analysis of my terraform templates.
