### PR TITLE
add fd - A simple, fast and user-friendly alternative to 'find'

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Currently supported distributions are:
 - [dw-query-digest](https://github.com/devops-works/dw-query-digest)
 - [exa](https://github.com/ogham/exa)
 - [eksctl](https://github.com/weaveworks/eksctl/)
+- [fd](https://github.com/sharkdp/fd)
 - [fzf](https://github.com/junegunn/fzf)
 - [gbt](https://github.com/jtyr/gbt)
 - [gdu](https://github.com/dundee/gdu/)

--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -310,6 +310,18 @@ sources:
       binaries:
         - dw-query-digest
 
+  fd:
+    description: A simple, fast and user-friendly alternative to 'find'
+    list:
+      type: github-releases
+      url: https://api.github.com/repos/sharkdp/fd/releases
+    fetch:
+      url: https://github.com/sharkdp/fd/releases/download/v{{ .Version }}/fd-v{{ .Version }}-x86_64-unknown-{{ .OS }}-gnu.tar.gz
+    install:
+      type: tgz
+      binaries:
+        - fd
+
   fzf:
     description: fzf is a general-purpose command-line fuzzy finder.
     list:


### PR DESCRIPTION
```
binenv update fd -f
updating distributions 100% |███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (1/1, 6139 it/s)

binenv install fd
2021-04-28T08:54:24+06:00 WRN version for "fd" not specified; using "8.2.1"
fetching fd version 8.2.1 100% |████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (1.1/1.1 MB, 2.648 MB/s)
2021-04-28T08:54:25+06:00 INF "fd" (8.2.1) installed
```