### PR TITLE
Adds ripgrep (`rg`) for MacOS, Linux, Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Currently supported distributions are:
 - [promtail](https://github.com/grafana/loki/)
 - [pulumi](https://github.com/pulumi/pulumi)
 - [rancher](https://rancher.com/docs/rancher/v1.6/en/)[^1]
+- [ripgrep](https://github.com/BurntSushi/ripgrep) (`rg`)
 - [saml2aws](https://github.com/Versent/saml2aws)
 - [scan-exporter](https://github.com/devops-works/scan-exporter)
 - [shaloc](https://github.com/eze-kiel/shaloc)

--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -1237,6 +1237,23 @@ sources:
       binaries:
         - "rancher-v{{ .Version }}/rancher"
 
+  rg:
+    description: ripgrep is a line-oriented search tool that recursively searches your current directory for a regex pattern
+    map:
+      amd64: x86_64
+      darwin: apple-darwin
+      linux: unknown-linux-musl
+      windows: pc-windows-msvc
+    list:
+      type: github-releases
+      url: https://api.github.com/repos/BurntSushi/ripgrep/releases
+    fetch:
+      url: https://github.com/BurntSushi/ripgrep/releases/download/{{ .Version }}/ripgrep-{{ .Version }}-{{ .Arch }}-{{ .OS }}.tar.gz
+    install:
+      type: tgz
+      binaries:
+        - rg
+
   saml2aws:
     description: >
       CLI tool which enables you to login and retrieve AWS temporary


### PR DESCRIPTION
Added the package to the distribution as `rg` to prevent the binary being installed as `ripgrep`. I don't think the install package currently has a function to specify the target binary name. 