### PR TITLE
add chisel

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Currently supported distributions are:
 - [cheat](https://github.com/cheat/cheat)
 - [check-tls-cert](https://github.com/heartbeatsjp/check-tls-cert)
 - [chezmoi](https://github.com/twpayne/chezmoi)
+- [chisel](https://github.com/jpillora/chisel)
 - [choose](https://github.com/theryangeary/choose)
 - [cli53](https://github.com/barnybug/cli53)
 - [clog-cli](https://github.com/clog-tool/clog-cli)

--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -308,6 +308,18 @@ sources:
       binaries:
         - chezmoi
 
+  chisel:
+    description: A fast TCP/UDP tunnel over HTTP
+    list:
+      type: github-releases
+      url: https://api.github.com/repos/jpillora/chisel/releases
+    fetch:
+      url: https://github.com/jpillora/chisel/releases/download/v{{ .Version }}/chisel_{{ .Version }}_{{ .OS }}_{{ .Arch }}.gz
+    install:
+      type: gzip
+      binaries:
+        - chisel
+
   choose:
     description: A human-friendly and fast alternative to cut and (sometimes) awk
     list:


### PR DESCRIPTION
binenv install chisel
2021-08-03T11:17:57+06:00 WRN version for "chisel" not specified; using "1.7.6"
fetching chisel version 1.7.6 100% |███████████████████████████████████████████████████████████████████████████████████████████████████████| (3.1/3.1 MB, 1.433 MB/s)        
2021-08-03T11:18:00+06:00 INF "chisel" (1.7.6) installed