### PR TITLE
Adds grafana-kiosk to distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Currently supported distributions are:
 - [gotop](https://github.com/xxxserxxx/gotop)
 - [gotty](https://github.com/yudai/gotty)
 - [gping](https://github.com/orf/gping)
+- [grafana-kiosk](https://github.com/grafana/grafana-kiosk/)
 - [grex](https://github.com/pemistahl/grex)
 - [grizzly](https://github.com/grafana/grizzly)
 - [grype](https://github.com/anchore/grype)

--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -803,6 +803,16 @@ sources:
       binaries:
         - gping
 
+  grafana-kiosk:
+    description: Kiosk utility for Grafana
+    list:
+      type: github-releases
+      url: https://api.github.com/repos/grafana/grafana-kiosk/releases
+    fetch:
+      url: https://github.com/grafana/grafana-kiosk/releases/download/v{{ .Version }}/grafana-kiosk.{{ .OS }}.{{ .Arch }}
+    install:
+      type: direct
+
   grex:
     description: A command-line tool and library for generating regular expressions from user-provided test cases
     map:


### PR DESCRIPTION
```
❯ binenv install grafana-kiosk 
2021-08-19T10:13:13+02:00 WRN version for "grafana-kiosk" not specified; using "1.0.4"
fetching grafana-kiosk version 1.0.4 100% |█████████████| (12/12 MB, 7.200 MB/s)        
2021-08-19T10:13:16+02:00 INF "grafana-kiosk" (1.0.4) installed
```