### PR TITLE
Adds migrate to distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Currently supported distributions are:
 - [lsd](https://github.com/Peltoche/lsd)
 - [mcfly](https://github.com/cantino/mcfly)
 - [micro](https://github.com/zyedidia/micro)
+- [migrate](https://github.com/golang-migrate/migrate)
 - [minikube](https://github.com/kubernetes/minikube)
 - [mysql_random_data_load](https://github.com/Percona-Lab/mysql_random_data_load)
 - [naabu](https://github.com/projectdiscovery/naabu)

--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -1579,6 +1579,18 @@ sources:
       binaries:
         - micro
 
+  migrate:
+    description: CLI database migrations tool.
+    list:
+      type: github-releases
+      url: https://api.github.com/repos/golang-migrate/migrate/releases
+    fetch:
+      url: https://github.com/golang-migrate/migrate/releases/download/v{{ .Version }}/migrate.{{ .OS }}-{{ .Arch }}.tar.gz
+    install:
+      type: tgz
+      binaries:
+        - ./migrate.{{ .OS }}-{{ .Arch }}
+
   minikube:
     description: Run Kubernetes locally
     list:


### PR DESCRIPTION
```
❯ binenv install migrate 
2021-08-20T11:23:09+02:00 WRN version for "migrate" not specified; using "4.14.1"
fetching migrate version 4.14.1 100% |████████| (16/16 MB, 7.056 MB/s)        
2021-08-20T11:23:13+02:00 INF "migrate" (4.14.1) installed
```