### PR TITLE
bug: fixed name and downloaded binary for kube-no-trouble

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Currently supported distributions are:
 - [kops](https://kops.sigs.k8s.io/)
 - [kube-bench](https://github.com/aquasecurity/kube-bench)
 - [kube-dump](https://github.com/WoozyMasta/kube-dump)
-- [kube-no-trouble](https://github.com/doitintl/kube-no-trouble)
+- [kubent](https://github.com/doitintl/kube-no-trouble)
 - [kubeaudit](https://github.com/Shopify/kubeaudit)
 - [kubecolor](https://github.com/dty1er/kubecolor)
 - [kubeconf](https://github.com/mumoshu/kubeconf)

--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -1325,8 +1325,8 @@ sources:
     install:
       type: direct
 
-  kube-no-trouble:
-    description: Easily check your clusters for use of deprecated APIs
+  kubent:
+    description: kube-no-trouble - Easily check your clusters for use of deprecated APIs
     list:
       type: github-releases
       url: https://api.github.com/repos/doitintl/kube-no-trouble/releases
@@ -1335,7 +1335,7 @@ sources:
     install:
       type: tgz
       binaries:
-        - kube-no-trouble
+        - kubent
 
   kubeaudit:
     description: kubeaudit helps you audit your Kubernetes clusters against common security controls


### PR DESCRIPTION
bugfix: kube-no-trouble binary is called kubent
change: renamed kube-no-trouble to kubent in distributions