### PR TITLE
fix: fetch url from eksctl is prefixed by a 'v'

### DIFF
--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -569,7 +569,7 @@ sources:
       type: github-releases
       url: https://api.github.com/repos/weaveworks/eksctl/releases
     fetch:
-      url: https://github.com/weaveworks/eksctl/releases/download/{{ .Version }}/eksctl_{{ .OS }}_{{ .Arch }}.tar.gz
+      url: https://github.com/weaveworks/eksctl/releases/download/v{{ .Version }}/eksctl_{{ .OS }}_{{ .Arch }}.tar.gz
     install:
       type: tgz
       binaries:


### PR DESCRIPTION
The fetch url from eksctl changed: The version in the url is prefixed by the letter 'v'