### PR TITLE
Adds infracost to distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Currently supported distributions are:
 - [hugo](https://gohugo.io/)
 - [iamlive](https://github.com/iann0036/iamlive)
 - [imgpkg](https://github.com/vmware-tanzu/carvel-imgpkg)
+- [infracost](https://github.com/infracost/infracost/)
 - [juicefs](https://github.com/juicedata/juicefs)
 - [k3d](https://github.com/rancher/k3d)
 - [k6](https://github.com/loadimpact/k6)

--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -1198,6 +1198,18 @@ sources:
     install:
       type: direct
 
+  infracost:
+    description:  Cloud cost estimates for Terraform
+    list:
+      type: github-releases
+      url: https://api.github.com/repos/infracost/infracost/releases
+    fetch:
+      url: https://github.com/infracost/infracost/releases/download/v{{ .Version }}/infracost-{{ .OS }}-{{ .Arch }}.tar.gz
+    install:
+      type: tgz
+      binaries:
+        - "infracost-{{ .OS }}-{{ .Arch }}"
+
   juicefs:
     description: JuiceFS is a distributed POSIX file system built on top of Redis and S3.
     list:


### PR DESCRIPTION
```
❯ binenv install infracost
2021-10-19T12:27:07+02:00 WRN version for "infracost" not specified; using "0.9.11"
fetching infracost version 0.9.11 100% |██████| (13/13 MB, 3.039 MB/s)        
2021-10-19T12:27:13+02:00 INF "infracost" (0.9.11) installed
```