### PR TITLE
docs: add install info block for OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The last binary you'll ever install.
     - [MacOS (with bash)](#macos-with-bash)
     - [Windows](#windows)
     - [FreeBSD (bash/zsh)](#freebsd-bashzsh)
+    - [OpenBSD (bash/zsh)](#openbsd-bashzsh)
   - [Install](#install)
   - [Updating binenv](#updating-binenv)
   - [Supported "distributions"](#supported-distributions)
@@ -105,6 +106,27 @@ wget -q https://github.com/devops-works/binenv/releases/latest/download/binenv_f
 wget -q https://github.com/devops-works/binenv/releases/latest/download/checksums.txt
 sha256sum  --check --ignore-missing checksums.txt
 mv binenv_freebsd_amd64 binenv
+chmod +x binenv
+./binenv update
+./binenv install binenv
+rm binenv
+if [[ -n $BASH ]]; then ZESHELL=bash; fi
+if [[ -n $ZSH_NAME ]]; then ZESHELL=zsh; fi
+echo $ZESHELL
+echo -e '\nexport PATH=~/.binenv:$PATH' >> ~/.${ZESHELL}rc
+echo "source <(binenv completion ${ZESHELL})" >> ~/.${ZESHELL}rc
+exec $SHELL
+```
+
+If you are using a different shell, skip adding completion to your `.${SHELL}rc` file.
+
+### OpenBSD (bash/zsh)
+
+```
+ftp https://github.com/devops-works/binenv/releases/latest/download/binenv_openbsd_amd64
+ftp https://github.com/devops-works/binenv/releases/latest/download/checksums.txt
+cksum -a sha256 -C checksums.txt binenv_openbsd_amd64
+mv binenv_openbsd_amd64 binenv
 chmod +x binenv
 ./binenv update
 ./binenv install binenv


### PR DESCRIPTION
Notes: 

- yes, OpenBSD still uses `ftp` utility as preferred way to download files
- `cksum` is in the base so there's no neet to install some extra packages to download and verify `binenv`

And I've tested the installation itself and package installation too. It all looks OK.