### PR TITLE
feature: Added command to upgrade all installed binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The last binary you'll ever install.
       - [Freezing versions](#freezing-versions)
     - [Uninstalling versions](#uninstalling-versions)
       - [Examples](#examples-3)
+    - [Upgrading all installed distributions](#upgrading-all-installed-distributions)
     - [Completion](#completion)
   - [Selecting versions](#selecting-versions)
     - [Version selection process](#version-selection-process)
@@ -410,6 +411,14 @@ The command accepts:
 
 Install completion for your shell. See `binenv help completion` for in-depth
 info.
+
+### Upgrading all installed distributions
+
+To upgrade all installed distributions to the last known version invoke the
+command `upgrade`
+
+This command will always select the last version available and will ignore any
+version selection previously made by the user.
 
 ## Selecting versions
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,7 @@ selected.`,
 		updateCmd(a),
 		versionCmd(),
 		versionsCmd(a),
+		upgradeCmd(a),
 	)
 
 	return rootCmd

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"github.com/devops-works/binenv/internal/app"
+	"github.com/spf13/cobra"
+)
+
+// upgradeCmd upgrade all installed distributions
+func upgradeCmd(a *app.App) *cobra.Command {
+	var bindir string
+	var ignoreInstallErrors bool
+
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade all installed distributions",
+		Long:  `Upgrade all installed distributions to the last version available on cache.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			verbose, _ := cmd.Flags().GetBool("verbose")
+
+			a.SetVerbose(verbose)
+			a.SetBinDir(bindir)
+			a.Upgrade(ignoreInstallErrors)
+		},
+	}
+
+	cmd.Flags().StringVarP(&bindir, "bindir", "b", app.GetDefaultBinDir(), "Binaries directory")
+	cmd.Flags().BoolVarP(&ignoreInstallErrors, "ignore-install-errors", "i", true, "Ignore install errors during upgrade")
+
+	return cmd
+}


### PR DESCRIPTION
I use Arch Linux, so I like to always have the last available version of everything... even if it breaks my workstation.

Here is a proposal to implement a `upgrade` command to blindly install the last known version of all installed binaries.

It should satisfy https://github.com/devops-works/binenv/issues/63