### PR TITLE
Feature: Add awslabs/ssosync

### DIFF
--- a/DISTRIBUTIONS.md
+++ b/DISTRIBUTIONS.md
@@ -214,6 +214,7 @@
 - [spt](https://github.com/Rigellute/spotify-tui/): A Spotify client for the terminal written in Rust.
 - [sshproxy](https://github.com/cea-hpc/sshproxy/): Proxy SSH connections on a gateway
 - [ssllabs-scan](https://github.com/ssllabs/ssllabs-scan/): A command-line reference-implementation client for SSL Labs APIs, designed for automated and/or bulk testing.
+- [ssosync](https://github.com/awslabs/ssosync/): Populate AWS SSO directly with your G Suite users and groups using either a CLI or AWS Lambda
 - [starship](https://github.com/starship/starship/): The minimal, blazing-fast, and infinitely customizable prompt for any shell!
 - [stern](https://github.com/stern/stern/): ⎈ Multi pod and container log tailing for Kubernetes -- Friendly fork of https://github.com/wercker/stern
 - [stoppropaganda](https://github.com/erkexzcx/stoppropaganda/): DOS application to stop pro-Russian aggression websites. Support Ukraine!

--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -3333,6 +3333,37 @@ sources:
       binaries:
         - ssllabs-scan
 
+  ssosync:
+    description: Populate AWS SSO directly with your G Suite users and groups using either a CLI or AWS Lambda 
+    url: https://github.com/awslabs/ssosync/
+    map:
+      amd64: x86_64
+      arm: armv6
+      darwin: Darwin
+      linux: Linux
+    list:
+      type: github-releases
+      url: https://api.github.com/repos/awslabs/ssosync/releases
+    fetch:
+      url: https://github.com/awslabs/ssosync/releases/download/v{{ .Version }}/ssosync_{{ .OS }}_{{ .Arch }}.tar.gz
+    install:
+      type: tgz
+      binaries:
+        - ssosync
+    supported_platforms:
+      - os: darwin
+        arch: arm64
+      - os: darwin
+        arch: amd64
+      - os: linux
+        arch: arm64
+      - os: linux
+        arch: arm
+      - os: linux
+        arch: i386
+      - os: linux
+        arch: amd64
+
   starship:
     description: The minimal, blazing-fast, and infinitely customizable prompt for any shell!
     url: https://github.com/starship/starship/


### PR DESCRIPTION
This package also provides releases for Windows platform, however Windows releases are packaged using `zip` not `tgz` and I don't see support for multiple install types or multiple urls

Should I also update cache, or is that done separately?