### PR TITLE
Add `steampipe`

### DIFF
--- a/DISTRIBUTIONS.md
+++ b/DISTRIBUTIONS.md
@@ -220,6 +220,7 @@
 - [ssllabs-scan](https://github.com/ssllabs/ssllabs-scan/): A command-line reference-implementation client for SSL Labs APIs, designed for automated and/or bulk testing.
 - [ssosync](https://github.com/awslabs/ssosync/): Populate AWS SSO directly with your G Suite users and groups using either a CLI or AWS Lambda
 - [starship](https://github.com/starship/starship/): The minimal, blazing-fast, and infinitely customizable prompt for any shell!
+- [steampipe](https://github.com/turbot/steampipe): Use SQL to instantly query your cloud services (AWS, Azure, GCP and more). Open source CLI. No DB required.
 - [stern](https://github.com/stern/stern/): ⎈ Multi pod and container log tailing for Kubernetes -- Friendly fork of https://github.com/wercker/stern
 - [stoppropaganda](https://github.com/erkexzcx/stoppropaganda/): DOS application to stop pro-Russian aggression websites. Support Ukraine!
 - [subfinder](https://github.com/projectdiscovery/subfinder/): Subfinder is a subdomain discovery tool that discovers valid subdomains for websites. Designed as a passive framework to be useful for bug bounties and safe for penetration testing.

--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -3444,6 +3444,24 @@ sources:
       binaries:
         - starship
 
+  steampipe:
+    description: Use SQL to instantly query your cloud services (AWS, Azure, GCP and more). Open source CLI. No DB required.
+    url: https://github.com/turbot/steampipe
+    list:
+      type: github-releases
+      url: https://api.github.com/repos/turbot/steampipe/releases
+    fetch:
+      url: https://github.com/turbot/steampipe/releases/download/v{{ .Version }}/steampipe_{{ .OS }}_{{ .Arch }}.tar.gz
+    install:
+      type: tgz
+      binaries:
+        - steampipe
+    supported_platforms:
+      - os: linux
+        arch: arm64
+      - os: linux
+        arch: amd64
+
   stern:
     description: >
       ⎈ Multi pod and container log tailing for Kubernetes -- Friendly fork of


### PR DESCRIPTION
Sadly there's a mismatch in archive types - .tar.gz for Linux and .zip for Darwin. So I added only Linux support.

I think this situation could be handled. @leucos, what do you think?