### PR TITLE
Adds lazydocker

### DIFF
--- a/DISTRIBUTIONS.md
+++ b/DISTRIBUTIONS.md
@@ -151,6 +151,7 @@
 - [kubetail](https://github.com/jbvmio/kubetail/): Repository for kubetail - The pod log tailer
 - [kubeval](https://github.com/instrumenta/kubeval/): Validate your Kubernetes configuration files, supports multiple Kubernetes versions
 - [kustomize](https://github.com/kubernetes-sigs/): Customization of kubernetes YAML configurations
+- [lazydocker](https://github.com/jesseduffield/lazydocker/): The lazier way to manage everything docker
 - [lazygit](https://github.com/jesseduffield/lazygit/): A simple terminal UI for git commands.
 - [linkerd](https://github.com/linkerd/linkerd2/): Linkerd is an ultralight, security-first service mesh for Kubernetes. Linkerd adds critical security, observability, and reliability features to your Kubernetes stack with no code change required.
 - [local-php-security-checker](https://github.com/fabpot/local-php-security-checker/): PHP security vulnerabilities checker

--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -2276,6 +2276,23 @@ sources:
       binaries:
         - kustomize
 
+  lazydocker:
+    description: The lazier way to manage everything docker
+    url: https://github.com/jesseduffield/lazydocker/
+    map:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+    list:
+      type: github-releases
+      url: https://api.github.com/repos/jesseduffield/lazydocker/releases
+    fetch:
+      url: https://github.com/jesseduffield/lazydocker/releases/download/v{{ .Version }}/lazydocker_{{ .Version }}_{{ .OS }}_{{ .Arch }}.tar.gz
+    install:
+      type: tgz
+      binaries:
+        - lazydocker
+
   # Note that https://github.com/jesseduffield/lazygit/issues/1791 can break
   # future deployments
   lazygit:


### PR DESCRIPTION
```
❯ binenv update lazydocker -f
updating distributions 100% |████| (1/1, 22357 it/s)

❯ binenv install lazydocker
2022-10-29T12:33:35+02:00 WRN version for "lazydocker" not specified; using "0.19.0"
fetching lazydocker version 0.19.0 100% |████| (3.7/3.7 MB, 962.106 kB/s)        
2022-10-29T12:33:40+02:00 INF "lazydocker" (0.19.0) installed
```