### PR TITLE
Added darwin/arm64 to the list of supported platforms for binenv

### DIFF
--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -271,6 +271,8 @@ sources:
         arch: arm64
       - os: darwin
         arch: amd64
+      - os: darwin
+        arch: arm64
       - os: openbsd
         arch: i386
       - os: openbsd


### PR DESCRIPTION
darwin/arm64 build seems to be available for a while but it is still not possible to install it through `./binenv install binenv`. It fails with the following message: `ERR "binenv" is not available for darwin/arm64`

This pr is an attempt to fix the issue and the fact dawin/arm64 is missing under supported_platforms in the distributions.yaml seems to be the only reason for this to happen