### PR TITLE
Fix Linkerd

### DIFF
--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -2354,7 +2354,7 @@ sources:
       url: https://api.github.com/repos/linkerd/linkerd2/releases
     fetch:
       filters: filters
-      url: https://github.com/linkerd/linkerd2/releases/download/{{ .Version }}{{ .OS }}-{{ .Arch }}
+      url: https://github.com/linkerd/linkerd2/releases/download/{{ .Version }}/linkerd2-cli-{{ .Version }}-{{ .OS }}-{{ .Arch }}
     install:
       type: direct
       binaries:


### PR DESCRIPTION
Hello,

I noticed Linkerd wasn't working as expected (only showing old versions), and it turns out they changed their release naming system.
This is a patch to address that.

To make it easier to verify, an example of the asset URL is:
`https://github.com/linkerd/linkerd2/releases/download/stable-2.12.3/linkerd2-cli-stable-2.12.3-linux-amd64`
where `stable-2.12.3` is the version identifier.

Thanks!