### PR TITLE
Fix user install download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ If you are using a different shell, skip adding completion to your `.${SHELL}rc`
 http://github.com/devops-works/binenv/releases.
 
 ```
-wget -q https://github.com/devops-works/binenv/releases/download/v0.19.0/binenv-<OS>-<ARCH>
+wget -q https://github.com/devops-works/binenv/releases/download/v0.19.0/binenv_<OS>_<ARCH>
 ```
 
 - rename it


### PR DESCRIPTION
I guessed the OS and ARCH placeholders and still got a 404 because the dashes were supposed to be underscores.

Before change:

```
$ wget https://github.com/devops-works/binenv/releases/download/v0.19.0/binenv-linux-amd64
--2023-06-23 08:18:44--  https://github.com/devops-works/binenv/releases/download/v0.19.0/binenv-linux-amd64
Resolving github.com (github.com)... 140.82.121.3
Connecting to github.com (github.com)|140.82.121.3|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2023-06-23 08:18:45 ERROR 404: Not Found.
```

After change:

```
$ wget https://github.com/devops-works/binenv/releases/download/v0.19.0/binenv_linux_amd64
--2023-06-23 08:19:31--  https://github.com/devops-works/binenv/releases/download/v0.19.0/binenv_linux_amd64
Resolving github.com (github.com)... 140.82.121.4
Connecting to github.com (github.com)|140.82.121.4|:443... connected.
HTTP request sent, awaiting response... 302 Found
...
```