### PR TITLE
remove dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,10 +607,9 @@ sudo ~/.binenv/binaries/termshark/2.2.0
 Sorry to hear that. Don't hesitate opening an issue or sending a PR is
 something does not fit your use case
 
-Some nice alternatives exist:
+A nice alternative exists:
 
-- https://gofi.sh/
-- https://asdf-vm.com/#/
+- https://asdf-vm.com/
 
 ## Distributions file format
 


### PR DESCRIPTION
The GoFish "repository has been archived by the owner on Mar 8, 2022. It is now read-only." See https://github.com/fishworks/gofish

https://gofi.sh/ dead some time after archiving.
See https://web.archive.org/web/20220228024138/https://gofi.sh/