### PR TITLE
Respecting XDG vars correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,13 +555,16 @@ Two other environment variables exist:
 
 ## Removing binenv stuff
 
-`binenv` stores downloaded binaries in `~/.binenv/binaries`, and a cache in
-`~/.config/binenv/` (or whatever your `XDG_CONFIG` variable points to).
+`binenv` stores 
+
+- downloaded binaries by default in `~/.binenv/binaries`
+- the versions cache in `~/.cache/binenv/` (or wherever your `XDG_CACHE_HOME` variable points to)
+- the list of known distributions in `~/.config/binenv/` (or wherever your `XDG_CONFIG_HOME` variable points to).
 
 To wipe everything clean:
 
 ```bash
-rm -rfi ~/.binenv ~/.config/binenv/
+rm -rfi ~/.binenv ~/.config/binenv ~/.cache/binenv
 ```
 
 Don't forget to remove the `PATH` and the completion you might have changed in

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -35,10 +35,10 @@ func GetDefaultConfDir() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		d += "/.config/binenv"
+		d += "/.config"
 	}
 
-	return d, nil
+	return d + "/binenv", nil
 }
 
 // GetDefaultCacheDir returns the cache directory in usermode
@@ -51,10 +51,10 @@ func GetDefaultCacheDir() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		d += "/.cache/binenv"
+		d += "/.cache"
 	}
 
-	return d, nil
+	return d + "/binenv", nil
 }
 
 func stringInSlice(st string, sl []string) bool {


### PR DESCRIPTION
distributions:  XDG_CONFIG_HOME + '/binenv/'
cache:          XDG_CACHE_HOME + '/binenv/'

🧨 this might break tools relying on the old places!

Fixes #241