### PR TITLE
Fix completion for tools using __complete function

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,7 +83,7 @@ This is version ` + Version + ` built on ` + BuildDate + `.`,
 			// short circuit ShellCompNoDescRequestCmd handling
 			// for binaries completion completion handling
 			// (bit not for binenv)
-			if cmd.CalledAs() == cobra.ShellCompNoDescRequestCmd && !isItMe() {
+			if (cmd.CalledAs() == cobra.ShellCompNoDescRequestCmd || cmd.CalledAs() == cobra.ShellCompRequestCmd) && !isItMe() {
 				// we do not want the internal (cobra-generated)
 				// __completeNoDesc to be called since this would prevent
 				// shimmed binary to return its own completions


### PR DESCRIPTION
Before completion was only working when the actual binary was using ShellCompNoDescRequestCmd (__completeNoDesc). But some tools (like kubectl and helm) use ShellCompRequestCmd (__complete) which needs to be forwarded to the binary as well to make it work