### PR TITLE
popeye has switched from x84_64 file naming to

### DIFF
--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -3193,7 +3193,6 @@ sources:
     description: A Kubernetes cluster resource sanitizer
     url: https://github.com/derailed/popeye/
     map:
-      amd64: x86_64
       darwin: Darwin
       linux: Linux
       windows: Windows


### PR DESCRIPTION
amd64 with version v0.11.2

This change will break installing versions before v0.11.2