### PR TITLE
Update distributions.yaml for hetzner-k3s

### DIFF
--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -1775,6 +1775,28 @@ sources:
       type: tgz
       binaries:
         - hetty
+        
+  hetzner-k3s:
+    description: The easiest and fastest way to create production grade Kubernetes clusters in Hetzner Cloud
+    url: https://github.com/vitobotta/hetzner-k3s
+    map:
+      darwin: macos
+    supported_platforms:
+      - os: linux
+        arch: amd64
+      - os: linux
+        arch: arm64
+      - os: darwin
+        arch: amd64
+      - os: darwin
+        arch: arm64
+    list:
+      type: github-releases
+      url: https://api.github.com/repos/vitobotta/hetzner-k3s/releases
+    fetch:
+      url: https://github.com/vitobotta/hetzner-k3s/releases/download/v{{ .Version }}/hetzner-k3s-{{ .OS }}-{{ .Arch }}
+    install:
+      type: direct
 
   himalaya:
     description: 📫 CLI email client


### PR DESCRIPTION
as requested by you

guess these kvs match with https://github.com/vitobotta/hetzner-k3s/releases/tag/v2.0.8, have only linux/amd here. 