### PR TITLE
Update distributions.yaml for kubectl

### DIFF
--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -2322,7 +2322,7 @@ sources:
       type: tgz
       binaries:
         - kubeconform
-
+        
   kubectl:
     description: Production-Grade Container Scheduling and Management (cli)
     url: https://github.com/kubernetes/kubernetes/
@@ -2330,7 +2330,7 @@ sources:
       type: github-releases
       url: https://api.github.com/repos/kubernetes/kubernetes/releases
     fetch:
-      url: https://storage.googleapis.com/kubernetes-release/release/v{{ .Version }}/bin/{{ .OS }}/{{ .Arch }}/kubectl
+      url: https://dl.k8s.io/release/v{{ .Version }}/bin/{{ .OS }}/{{ .Arch }}/kubectl
     install:
       type: direct
 


### PR DESCRIPTION
since an hour ago the old url stopped working.

2024-09-20T23:13:06+02:00 ERR unable to install "kubectl" (1.31.1) error="unable to download binary at https://storage.googleapis.com/kubernetes-release/release/v1.31.1/bin/linux/amd64/kubectl: 404 Not Found"