### PR TITLE
Fix fzf version URL

### DIFF
--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -1211,7 +1211,8 @@ sources:
       type: github-releases
       url: https://api.github.com/repos/junegunn/fzf/releases
     fetch:
-      url: https://github.com/junegunn/fzf/releases/download/{{ .Version }}/fzf-{{ .Version }}-{{ .OS }}_{{ .Arch }}.tar.gz
+      #url: https://github.com/junegunn/fzf/releases/download/{{ .Version }}/fzf-{{ .Version }}-{{ .OS }}_{{ .Arch }}.tar.gz
+      url: https://github.com/junegunn/fzf/releases/download/v{{ .Version }}/fzf-{{ .Version }}-{{ .OS }}_{{ .Arch }}.tar.gz
     install:
       type: tgz
       binaries:


### PR DESCRIPTION
Since version `0.54.0` fzf releases are prefix with a `v`. Don't know how to handle this in a retro-compatible way tbh