### PR TITLE
distributions: Update binary pattern for micro

### DIFF
--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -1138,7 +1138,7 @@ sources:
     install:
       type: tgz
       binaries:
-        - fd
+        - ^fd$
 
   ffsend:
     description: Easily and securely share files from the command line. A fully featured Firefox Send client.

--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -2981,7 +2981,7 @@ sources:
     install:
       type: tgz
       binaries:
-        - micro
+        - ^micro$
 
   migrate:
     description: CLI database migrations tool.


### PR DESCRIPTION
The tarball `micro-2.0.14-linux64.tar.gz` contains two file matching the pattern:

```
$ tar -tf micro-2.0.14-linux64.tar.gz micro-2.0.14/
micro-2.0.14/
micro-2.0.14/micro.desktop
micro-2.0.14/micro.svg
micro-2.0.14/LICENSE
micro-2.0.14/README.md
micro-2.0.14/LICENSE-THIRD-PARTY
micro-2.0.14/micro
micro-2.0.14/micro.1
```

The patch update the pattern to match the exact filename `micro`