### PR TITLE
distributions: Update binary pattern for `fd`

### DIFF
--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -1138,7 +1138,7 @@ sources:
     install:
       type: tgz
       binaries:
-        - fd
+        - ^fd$
 
   ffsend:
     description: Easily and securely share files from the command line. A fully featured Firefox Send client.


### PR DESCRIPTION
https://github.com/devops-works/binenv/issues/261#issuecomment-2296063242

The patch fixes a specific issue with `fd` reported in #261

Though, it does not fixes the generic issue introduced by regexp matching.