### PR TITLE
feat: add nika distribution

### DIFF
--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -3361,6 +3361,31 @@ sources:
       binaries:
         - naabu
 
+  nika:
+    description: Workflow engine for AI - YAML DAGs statically checked before execution, tamper-evident traces after
+    url: https://github.com/supernovae-st/nika
+    map:
+      darwin: macos
+      amd64: x64
+    supported_platforms:
+      - os: linux
+        arch: amd64
+      - os: linux
+        arch: arm64
+      - os: darwin
+        arch: amd64
+      - os: darwin
+        arch: arm64
+    list:
+      type: github-releases
+      url: https://api.github.com/repos/supernovae-st/nika/releases
+    fetch:
+      url: https://github.com/supernovae-st/nika/releases/download/v{{ .Version }}/nika-{{ .OS }}-{{ .Arch }}-{{ .Version }}.tar.gz
+    install:
+      type: tgz
+      binaries:
+        - ^nika$
+
   node-problem-detector:
     description: This is a place for various problem detectors running on the Kubernetes nodes.
     url: https://github.com/kubernetes/node-problem-detector/


### PR DESCRIPTION
Adds nika (github.com/supernovae-st/nika — open-source AGPL Rust workflow engine for AI: YAML DAGs checked before execution, verified traces after). Entry follows the house shape: github-releases list, v-prefixed tag in the fetch template (circleci precedent), map darwin→macos + amd64→x64 matching the release asset names (nika-{os}-{arch}-{version}.tar.gz), tgz install with the single ^nika$ binary, four platforms matching what upstream actually ships (no windows — upstream does not ship it). Verified against the live v0.99.0 release assets. Disclosure: I am the nika author (first-party submission).