### PR TITLE
feat: add OutageDeck CLI

### DIFF
--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -3568,7 +3568,7 @@ sources:
 
   outagedeck:
     description: Check live cloud and SaaS provider status from the terminal
-    url: https://outagedeck.com/developers/cli?utm_source=binenv&utm_medium=package_manager&utm_campaign=cli_distribution
+    url: https://outagedeck.com/developers/cli
     list:
       type: github-releases
       url: https://api.github.com/repos/outagedeck/cli/releases

--- a/distributions/distributions.yaml
+++ b/distributions/distributions.yaml
@@ -3566,6 +3566,28 @@ sources:
       binaries:
         - oto
 
+  outagedeck:
+    description: Check live cloud and SaaS provider status from the terminal
+    url: https://outagedeck.com/developers/cli?utm_source=binenv&utm_medium=package_manager&utm_campaign=cli_distribution
+    list:
+      type: github-releases
+      url: https://api.github.com/repos/outagedeck/cli/releases
+    fetch:
+      url: https://github.com/outagedeck/cli/releases/download/v{{ .Version }}/outagedeck_{{ .Version }}_{{ .OS }}_{{ .Arch }}.tar.gz
+    install:
+      type: tgz
+      binaries:
+        - outagedeck
+    supported_platforms:
+      - os: linux
+        arch: amd64
+      - os: linux
+        arch: arm64
+      - os: darwin
+        arch: amd64
+      - os: darwin
+        arch: arm64
+
   oxker:
     description: Docker container management interface
     url: https://github.com/mrjackwills/oxker


### PR DESCRIPTION
## What changed

Adds OutageDeck CLI to binenv's distribution catalog for macOS and Linux on AMD64 and ARM64.

OutageDeck checks normalized official status feeds for cloud and SaaS providers. The command is useful when a deployment or local workflow looks broken and an upstream dependency may be the actual cause.

I'm Kerolos, founder of OutageDeck, and maintain the release assets used by this definition.

## Validation

- `go test ./...`
- `binenv update -f outagedeck` found versions 0.1.0 through 0.1.3
- `binenv install outagedeck 0.1.3` completed in an isolated layout
- The installed shim returned 0.1.3 and completed live GitHub and Cloudflare checks
- The combined cache validated all 320 distributions with no missing versions
- Confirmed release assets for all four declared OS and architecture targets
- `git diff --check`
